### PR TITLE
Add --famlily and --service option to any sub commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Usage: ecsta describe
 Describe tasks
 
 Flags:
-      --id=STRING         task ID
+      --id=STRING          task ID
+      --family=FAMILY      task definition family name
+      --service=SERVICE    ECS service name
 ```
 
 ### Exec task
@@ -116,6 +118,8 @@ Flags:
       --id=STRING           task ID
       --command="sh"        command to execute
       --container=STRING    container name
+      --family=FAMILY       task definition family name
+      --service=SERVICE     ECS service name
 ```
 
 ### Portforward task
@@ -133,6 +137,8 @@ Flags:
       --local-port=INT        local port
       --remote-port=INT       remote port
       --remote-host=STRING    remote host
+      --family=FAMILY         task definition family name
+      --service=SERVICE       ECS service name
 ```
 
 ### Stop task
@@ -145,6 +151,8 @@ Stop a task
 Flags:
       --id=STRING         task ID
       --force             stop without confirmation
+      --family=FAMILY     task definition family name
+      --service=SERVICE   ECS service name
 ```
 
 ### Trace task
@@ -160,6 +168,8 @@ Flags:
       --id=STRING               task ID
       --duration=1m             duration to trace
       --sns-topic-arn=STRING    SNS topic ARN
+      --family=FAMILY           task definition family name
+      --service=SERVICE         ECS service name
 ```
 
 ### Logs
@@ -174,6 +184,8 @@ Flags:
       --duration=1m         duration to start time
   -f, --follow              follow logs
       --container=STRING    container name
+      --family=FAMILY       task definition family name
+      --service=SERVICE     ECS service name
 ```
 
 ## LICENSE

--- a/describe.go
+++ b/describe.go
@@ -6,14 +6,16 @@ import (
 )
 
 type DescribeOption struct {
-	ID string `help:"task ID"`
+	ID      string  `help:"task ID"`
+	Family  *string `help:"task definition family name"`
+	Service *string `help:"ECS service name"`
 }
 
 func (app *Ecsta) RunDescribe(ctx context.Context, opt *DescribeOption) error {
 	if err := app.SetCluster(ctx); err != nil {
 		return err
 	}
-	task, err := app.findTask(ctx, &optionFindTask{id: opt.ID})
+	task, err := app.findTask(ctx, &optionFindTask{id: opt.ID, family: opt.Family, service: opt.Service})
 	if err != nil {
 		return fmt.Errorf("failed to select tasks: %w", err)
 	}

--- a/describe.go
+++ b/describe.go
@@ -13,7 +13,7 @@ func (app *Ecsta) RunDescribe(ctx context.Context, opt *DescribeOption) error {
 	if err := app.SetCluster(ctx); err != nil {
 		return err
 	}
-	task, err := app.findTask(ctx, opt.ID)
+	task, err := app.findTask(ctx, &optionFindTask{id: opt.ID})
 	if err != nil {
 		return fmt.Errorf("failed to select tasks: %w", err)
 	}

--- a/ecsta.go
+++ b/ecsta.go
@@ -155,9 +155,15 @@ func (app *Ecsta) selectByFilter(ctx context.Context, src []string, title string
 	return res, nil
 }
 
-func (app *Ecsta) findTask(ctx context.Context, id string) (types.Task, error) {
-	if id != "" {
-		tasks, err := app.describeTasks(ctx, &optionDescribeTasks{ids: []string{id}})
+type optionFindTask struct {
+	id      string
+	family  *string
+	service *string
+}
+
+func (app *Ecsta) findTask(ctx context.Context, opt *optionFindTask) (types.Task, error) {
+	if opt.id != "" {
+		tasks, err := app.describeTasks(ctx, &optionDescribeTasks{ids: []string{opt.id}})
 		if err != nil {
 			return types.Task{}, err
 		}
@@ -165,7 +171,10 @@ func (app *Ecsta) findTask(ctx context.Context, id string) (types.Task, error) {
 			return tasks[0], nil
 		}
 	}
-	tasks, err := app.listTasks(ctx, &optionListTasks{})
+	tasks, err := app.listTasks(ctx, &optionListTasks{
+		family:  opt.family,
+		service: opt.service,
+	})
 	if err != nil {
 		return types.Task{}, err
 	}
@@ -179,7 +188,7 @@ func (app *Ecsta) findTask(ctx context.Context, id string) (types.Task, error) {
 	if err != nil {
 		return types.Task{}, fmt.Errorf("failed to run filter: %w", err)
 	}
-	id = strings.SplitN(res, "\t", 2)[0]
+	id := strings.SplitN(res, "\t", 2)[0]
 	for _, task := range tasks {
 		if arnToName(*task.TaskArn) == id {
 			return task, nil

--- a/exec.go
+++ b/exec.go
@@ -14,16 +14,18 @@ import (
 const SessionManagerPluginBinary = "session-manager-plugin"
 
 type ExecOption struct {
-	ID        string `help:"task ID"`
-	Command   string `help:"command to execute" default:"sh"`
-	Container string `help:"container name"`
+	ID        string  `help:"task ID"`
+	Command   string  `help:"command to execute" default:"sh"`
+	Container string  `help:"container name"`
+	Family    *string `help:"task definiton family name"`
+	Service   *string `help:"ECS service name"`
 }
 
 func (app *Ecsta) RunExec(ctx context.Context, opt *ExecOption) error {
 	if err := app.SetCluster(ctx); err != nil {
 		return err
 	}
-	task, err := app.findTask(ctx, opt.ID)
+	task, err := app.findTask(ctx, &optionFindTask{id: opt.ID, family: opt.Family, service: opt.Service})
 	if err != nil {
 		return fmt.Errorf("failed to select tasks: %w", err)
 	}

--- a/logs.go
+++ b/logs.go
@@ -15,17 +15,19 @@ import (
 )
 
 type LogsOption struct {
-	ID       string        `help:"task ID"`
-	Duration time.Duration `help:"duration to start time" default:"1m"`
-	Follow   bool          `help:"follow logs" short:"f"`
-	Container string       `help:"container name"`
+	ID        string        `help:"task ID"`
+	Duration  time.Duration `help:"duration to start time" default:"1m"`
+	Follow    bool          `help:"follow logs" short:"f"`
+	Container string        `help:"container name"`
+	Family    *string       `help:"task definiton family name"`
+	Service   *string       `help:"ECS service name"`
 }
 
 func (app *Ecsta) RunLogs(ctx context.Context, opt *LogsOption) error {
 	if err := app.SetCluster(ctx); err != nil {
 		return err
 	}
-	task, err := app.findTask(ctx, opt.ID)
+	task, err := app.findTask(ctx, &optionFindTask{id: opt.ID, family: opt.Family, service: opt.Service})
 	if err != nil {
 		return fmt.Errorf("failed to select tasks: %w", err)
 	}

--- a/portforward.go
+++ b/portforward.go
@@ -13,18 +13,20 @@ import (
 )
 
 type PortforwardOption struct {
-	ID         string `help:"task ID"`
-	Container  string `help:"container name"`
-	LocalPort  int    `help:"local port" required:"true"`
-	RemotePort int    `help:"remote port" required:"true"`
-	RemoteHost string `help:"remote host"`
+	ID         string  `help:"task ID"`
+	Container  string  `help:"container name"`
+	LocalPort  int     `help:"local port" required:"true"`
+	RemotePort int     `help:"remote port" required:"true"`
+	RemoteHost string  `help:"remote host"`
+	Family     *string `help:"task definiton family name"`
+	Service    *string `help:"ECS service name"`
 }
 
 func (app *Ecsta) RunPortforward(ctx context.Context, opt *PortforwardOption) error {
 	if err := app.SetCluster(ctx); err != nil {
 		return err
 	}
-	task, err := app.findTask(ctx, opt.ID)
+	task, err := app.findTask(ctx, &optionFindTask{id: opt.ID, family: opt.Family, service: opt.Service})
 	if err != nil {
 		return fmt.Errorf("failed to select tasks: %w", err)
 	}

--- a/stop.go
+++ b/stop.go
@@ -10,15 +10,17 @@ import (
 )
 
 type StopOption struct {
-	ID    string `help:"task ID"`
-	Force bool   `help:"stop without confirmation"`
+	ID      string  `help:"task ID"`
+	Force   bool    `help:"stop without confirmation"`
+	Family  *string `help:"task definition family name"`
+	Service *string `help:"ECS service name"`
 }
 
 func (app *Ecsta) RunStop(ctx context.Context, opt *StopOption) error {
 	if err := app.SetCluster(ctx); err != nil {
 		return err
 	}
-	task, err := app.findTask(ctx, opt.ID)
+	task, err := app.findTask(ctx, &optionFindTask{id: opt.ID, family: opt.Family, service: opt.Service})
 	if err != nil {
 		return fmt.Errorf("failed to select tasks: %w", err)
 	}

--- a/trace.go
+++ b/trace.go
@@ -12,13 +12,15 @@ type TraceOption struct {
 	ID          string        `help:"task ID"`
 	Duration    time.Duration `help:"duration to trace" default:"1m"`
 	SNSTopicArn string        `help:"SNS topic ARN"`
+	Family      *string       `help:"task definiton family name"`
+	Service     *string       `help:"ECS service name"`
 }
 
 func (app *Ecsta) RunTrace(ctx context.Context, opt *TraceOption) error {
 	if err := app.SetCluster(ctx); err != nil {
 		return err
 	}
-	task, err := app.findTask(ctx, opt.ID)
+	task, err := app.findTask(ctx, &optionFindTask{id: opt.ID, family: opt.Family, service: opt.Service})
 	if err != nil {
 		return fmt.Errorf("failed to select tasks: %w", err)
 	}


### PR DESCRIPTION
- --family: filter by task definition family name.
- --service: filter by ECS service name.

When both options are specified, it works OR context.