### PR TITLE
exec and portforward commands show tasks without the last status being "STOPPED".

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -25,7 +25,10 @@ func (app *Ecsta) RunExec(ctx context.Context, opt *ExecOption) error {
 	if err := app.SetCluster(ctx); err != nil {
 		return err
 	}
-	task, err := app.findTask(ctx, &optionFindTask{id: opt.ID, family: opt.Family, service: opt.Service})
+	task, err := app.findTask(ctx, &optionFindTask{
+		id: opt.ID, family: opt.Family, service: opt.Service,
+		selectFunc: selectFuncExcludeStopped,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to select tasks: %w", err)
 	}

--- a/portforward.go
+++ b/portforward.go
@@ -26,7 +26,10 @@ func (app *Ecsta) RunPortforward(ctx context.Context, opt *PortforwardOption) er
 	if err := app.SetCluster(ctx); err != nil {
 		return err
 	}
-	task, err := app.findTask(ctx, &optionFindTask{id: opt.ID, family: opt.Family, service: opt.Service})
+	task, err := app.findTask(ctx, &optionFindTask{
+		id: opt.ID, family: opt.Family, service: opt.Service,
+		selectFunc: selectFuncExcludeStopped,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to select tasks: %w", err)
 	}


### PR DESCRIPTION
Stopped tasks never accept an exec session.

https://github.com/kayac/ecspresso/issues/528