### PR TITLE
Handle os.Interrupt for graceful shutdown.

### DIFF
--- a/cmd/ecsta/main.go
+++ b/cmd/ecsta/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"os/signal"
 
 	"github.com/fujiwara/ecsta"
 )
@@ -16,6 +17,9 @@ func init() {
 
 func main() {
 	ctx := context.TODO()
+	ctx, stop := signal.NotifyContext(ctx, []os.Signal{os.Interrupt}...)
+	defer stop()
+
 	err := ecsta.RunCLI(ctx, os.Args[1:])
 	if err != nil {
 		log.Fatal(err)

--- a/ecsta.go
+++ b/ecsta.go
@@ -148,7 +148,7 @@ func (app *Ecsta) selectCluster(ctx context.Context) (string, error) {
 	for _, cluster := range clusters {
 		fmt.Fprintln(buf, arnToName(cluster))
 	}
-	res, err := app.runFilter(buf, "cluster name")
+	res, err := app.runFilter(ctx, buf, "cluster name")
 	if err != nil {
 		return "", fmt.Errorf("failed to run filter: %w", err)
 	}
@@ -160,7 +160,7 @@ func (app *Ecsta) selectByFilter(ctx context.Context, src []string, title string
 	for _, s := range src {
 		fmt.Fprintln(buf, s)
 	}
-	res, err := app.runFilter(buf, title)
+	res, err := app.runFilter(ctx, buf, title)
 	if err != nil {
 		return "", fmt.Errorf("failed to run filter: %w", err)
 	}
@@ -219,9 +219,12 @@ func (app *Ecsta) findTask(ctx context.Context, opt *optionFindTask) (types.Task
 		f.AddTask(task)
 	}
 	f.Close()
-	res, err := app.runFilter(buf, "task ID")
+	res, err := app.runFilter(ctx, buf, "task ID")
 	if err != nil {
 		return types.Task{}, fmt.Errorf("failed to run filter: %w", err)
+	}
+	if res == "" {
+		return types.Task{}, fmt.Errorf("task not selected")
 	}
 	id := strings.SplitN(res, "\t", 2)[0]
 	for _, task := range tasks {
@@ -237,6 +240,9 @@ func (app *Ecsta) SetCluster(ctx context.Context) error {
 		cluster, err := app.selectCluster(ctx)
 		if err != nil {
 			return err
+		}
+		if cluster == "" {
+			return fmt.Errorf("cluster not selected")
 		}
 		app.cluster = cluster
 	}


### PR DESCRIPTION
Using ecsta as a library, context should control any functions.

Fix `runInternalFilter`:
prompter.Prompt() cannot break by cancel of context. So add watchdog for the context and run prompter in another goroutine. 