### PR TITLE
kill session-manager-plugin when the task is stopping.

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 )
 
 const SessionManagerPluginBinary = "session-manager-plugin"
@@ -52,14 +53,29 @@ func (app *Ecsta) RunExec(ctx context.Context, opt *ExecOption) error {
 	if err != nil {
 		return fmt.Errorf("failed to execute command. %w See also https://github.com/aws-containers/amazon-ecs-exec-checker", err)
 	}
-	sess, _ := json.Marshal(out.Session)
-	ssmReq, err := buildSsmRequestParameters(task, opt.Container)
+	target, err := ssmRequestTarget(task, opt.Container)
 	if err != nil {
 		return fmt.Errorf("failed to build ssm request parameters: %w", err)
 	}
+
+	signal.Ignore(os.Interrupt)
+	return app.runSessionManagerPlugin(ctx, task, out.Session, target)
+}
+
+func (app *Ecsta) runSessionManagerPlugin(ctx context.Context, task types.Task, session *types.Session, target string) error {
 	endpoint, err := app.Endpoint(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get endpoint: %w", err)
+	}
+	sess, err := json.Marshal(session)
+	if err != nil {
+		return fmt.Errorf("failed to marshal session: %w", err)
+	}
+	ssmreq, err := json.Marshal(map[string]string{
+		"Target": target,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal ssm request parameters: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -71,15 +87,14 @@ func (app *Ecsta) RunExec(ctx context.Context, opt *ExecOption) error {
 		app.region,
 		"StartSession",
 		"",
-		ssmReq.String(),
+		string(ssmreq),
 		endpoint,
 	)
-	signal.Ignore(os.Interrupt)
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	go func() {
-		if err := app.watchTaskUntilStopped(ctx, aws.ToString(task.TaskArn)); err != nil {
+		if err := app.watchTaskUntilStopping(ctx, *task.TaskArn); err != nil {
 			log.Println(err)
 			cancel()
 		}
@@ -87,14 +102,14 @@ func (app *Ecsta) RunExec(ctx context.Context, opt *ExecOption) error {
 	return cmd.Run()
 }
 
-func (app *Ecsta) watchTaskUntilStopped(ctx context.Context, taskID string) error {
+func (app *Ecsta) watchTaskUntilStopping(ctx context.Context, taskID string) error {
 	ticker := time.NewTicker(10 * time.Second) // TODO: configurable
 	defer ticker.Stop()
 	var lastStatus string
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil
 		case <-ticker.C:
 		}
 		tasks, err := app.describeTasks(ctx, &optionDescribeTasks{
@@ -108,7 +123,7 @@ func (app *Ecsta) watchTaskUntilStopped(ctx context.Context, taskID string) erro
 		}
 		status := aws.ToString(tasks[0].LastStatus)
 		switch status {
-		case "STOPPED", "DELETED", "STOPPING", "DEPROVISIONING":
+		case "STOPPING", "DEPROVISIONING", "STOPPED", "DELETED":
 			return fmt.Errorf(
 				"%s is %s: %s (%s)",
 				taskID,

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,6 @@
 package ecsta
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -29,16 +28,7 @@ func arnToName(s string) string {
 	return ns[len(ns)-1]
 }
 
-type ssmRequestParameters struct {
-	Target string
-}
-
-func (p *ssmRequestParameters) String() string {
-	b, _ := json.Marshal(p)
-	return string(b)
-}
-
-func buildSsmRequestParameters(task types.Task, targetContainer string) (*ssmRequestParameters, error) {
+func ssmRequestTarget(task types.Task, targetContainer string) (string, error) {
 	values := strings.Split(*task.TaskArn, "/")
 	clusterName := values[1]
 	taskID := values[2]
@@ -48,7 +38,5 @@ func buildSsmRequestParameters(task types.Task, targetContainer string) (*ssmReq
 			runtimeID = *c.RuntimeId
 		}
 	}
-	return &ssmRequestParameters{
-		Target: fmt.Sprintf("ecs:%s_%s_%s", clusterName, taskID, runtimeID),
-	}, nil
+	return fmt.Sprintf("ecs:%s_%s_%s", clusterName, taskID, runtimeID), nil
 }


### PR DESCRIPTION
Currently, `ecsta exec` that is connected to an ECS task cannot disconnect the connection even if the ECS task was stopped.

This behavior is caused by the `session-manager-plugin`, but I added a workaround by myself.

- Run a goroutine to watch the last status of the task.
- When the task is stopping or later status in [task lifecycle](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle.html), the goroutine cancels the context of ssm.