### PR TITLE
setConfigDir called at once.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -26,8 +26,6 @@ type CLI struct {
 }
 
 func RunCLI(ctx context.Context, args []string) error {
-	setConfigDir()
-
 	var cli CLI
 	parser, err := kong.New(&cli, kong.Vars{"version": Version})
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/Songmu/prompter"
 )
@@ -100,6 +101,7 @@ type ConfigElement struct {
 }
 
 var configDir string
+var configOnce sync.Once
 
 const configSubdir = "ecsta"
 

--- a/ecsta.go
+++ b/ecsta.go
@@ -35,6 +35,7 @@ type Ecsta struct {
 }
 
 func New(ctx context.Context, region, cluster string) (*Ecsta, error) {
+	configOnce.Do(setConfigDir)
 	awscfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(region))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#16 breaks compatibility for use as a library.
`setConfigDir` is called at once in the `New()` function.