### PR TITLE
Fix/logs follow exit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: "1.20"
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
           args: release --rm-dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64

--- a/trace.go
+++ b/trace.go
@@ -34,5 +34,6 @@ func (app *Ecsta) RunTrace(ctx context.Context, opt *TraceOption) error {
 		Duration:    opt.Duration,
 		SNSTopicArn: opt.SNSTopicArn,
 	}
+	tr.SetOutput(app.w)
 	return tr.Run(ctx, app.cluster, *task.TaskArn, tracerOpt)
 }


### PR DESCRIPTION
Fix: `ecsta logs --follow` cannot break with Ctrl-C.