### PR TITLE
Add portforward -L flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,21 +136,36 @@ Flags:
 
 ### Portforward task
 
-`-local-port` and `-remote-port` are required.
+`-local-port` and `-remote-port`, or `-L` is required.
 
 ```
-Usage: ecsta portforward --local-port=INT --remote-port=INT
+Usage: ecsta portforward
 
 Forward a port of a task
 
 Flags:
-      --id=STRING             task ID
-      --container=STRING      container name
-      --local-port=INT        local port
-      --remote-port=INT       remote port
-      --remote-host=STRING    remote host
-      --family=FAMILY         task definition family name
-      --service=SERVICE       ECS service name
+      --id=STRING                   task ID
+      --container=STRING            container name
+      --local-port=INT              local port
+      --remote-port=INT             remote port
+      --remote-host=STRING          remote host
+  -L, --L=STRING                    short expression of local-port:remote-host:remote-port
+      --family=FAMILY               task definition family name
+      --service=SERVICE             ECS service name
+```
+
+An example of port forwarding. Forward a port 8080 of a task to 80 of example.com.
+
+```console
+$ ecsta portforward --local-port 8080 --remote-port 80 --remote-host example.com
+
+$ ecsta portforward -L 8080:example.com:80
+```
+
+ecsta connects to the task and starts a port forwarding. You can access the port 8080 of the local machine.
+
+```console
+$ curl -H"Host: example.com" http://localhost:8080
 ```
 
 ### Stop task

--- a/portforward.go
+++ b/portforward.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -13,14 +14,44 @@ import (
 type PortforwardOption struct {
 	ID         string  `help:"task ID"`
 	Container  string  `help:"container name"`
-	LocalPort  int     `help:"local port" required:"true"`
-	RemotePort int     `help:"remote port" required:"true"`
+	LocalPort  int     `help:"local port"`
+	RemotePort int     `help:"remote port"`
 	RemoteHost string  `help:"remote host"`
-	Family     *string `help:"task definiton family name"`
+	L          string  `name:"L" help:"short expression of local-port:remote-host:remote-port" short:"L"`
+	Family     *string `help:"task definition family name"`
 	Service    *string `help:"ECS service name"`
 }
 
+func (opt *PortforwardOption) ParseL() error {
+	if opt.L == "" {
+		return nil
+	}
+	parts := strings.SplitN(opt.L, ":", 3)
+	if len(parts) != 3 {
+		return fmt.Errorf("invalid format: %s", opt.L)
+	}
+	localPort, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("invalid local port: %s", parts[0])
+	}
+	remotePort, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return fmt.Errorf("invalid remote port: %s", parts[2])
+	}
+	opt.LocalPort = localPort
+	opt.RemoteHost = parts[1]
+	opt.RemotePort = remotePort
+	return nil
+}
+
 func (app *Ecsta) RunPortforward(ctx context.Context, opt *PortforwardOption) error {
+	if err := opt.ParseL(); err != nil {
+		return err
+	}
+	if opt.LocalPort == 0 || opt.RemotePort == 0 {
+		return fmt.Errorf("local-port and remote-port must be specified")
+	}
+
 	if err := app.SetCluster(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a short expression of `local-port:remote-host:remote-port` like ssh(1).

```console
$ ecsta portforward --local-port 8080 --remote-port 80 --remote-host example.com

$ ecsta portforward -L 8080:example.com:80
```