### PR TITLE
feat: update tncl to v0.0.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test install clean
 
-TNCL_VERSION=v0.0.4
+TNCL_VERSION=v0.0.5
 
 test:
 	TZ=Asia/Tokyo go test ./...


### PR DESCRIPTION
## Summary
• Update embedded tncl tool from v0.0.4 to v0.0.5 for improved file transfer functionality
• Download and verify new tncl binaries for both aarch64 and x86_64 architectures

## Test plan
- [x] Build verification: `go build -o ecsta ./cmd/ecsta/` succeeds
- [x] Test suite: `make test` passes
- [x] Asset download: `make download-assets` successfully retrieves v0.0.5 binaries

🤖 Generated with [Claude Code](https://claude.ai/code)