### PR TITLE
fix: exclude sibling services' tasks when both --family and --service are specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ $ ecsta list --cluster foo --output-tags --tags Env=prod
 | 4deeb701c49a4892b7de39a2d0df17e0 | ecspresso-test:499 |          | RUNNING    | RUNNING       | 2022-08-06T00:12:50+09:00 | service:nginx-local | FARGATE | Env=prod,Name=nginx-local |
 ```
 
+#### Filtering tasks by family and service
+
+The `--family` and `--service` flags are accepted by `list`, `describe`, `exec`, `portforward`, `cp`, `stop`, `trace`, and `logs`.
+
+The AWS `ListTasks` API does not allow `family` and `serviceName` to be specified at the same time. When both flags are passed to ecsta, tasks are listed by `family` and then post-filtered as follows:
+
+- Tasks belonging to the specified service are kept.
+- Tasks not associated with any service (typically launched via `RunTask`, e.g. `ecspresso run`) of the same family are kept.
+- Tasks belonging to other services that share the family are excluded.
+
+This is useful when several ECS services share a single task definition family: passing both `--family` and `--service` returns only the tasks that belong to the specified service plus its standalone runs.
+
 ### Describe task
 
 ```

--- a/cp.go
+++ b/cp.go
@@ -29,7 +29,7 @@ type CpOption struct {
 	ID        string  `help:"task ID"`
 	Container string  `help:"container name"`
 	Family    *string `help:"task definition family name"`
-	Service   *string `help:"ECS service name"`
+	Service   *string `help:"ECS service name. When combined with --family, tasks of other services sharing the family are excluded."`
 }
 
 func (cp *CpOption) SrcTarget() (string, string) {

--- a/describe.go
+++ b/describe.go
@@ -8,7 +8,7 @@ import (
 type DescribeOption struct {
 	ID      string  `help:"task ID"`
 	Family  *string `help:"task definition family name"`
-	Service *string `help:"ECS service name"`
+	Service *string `help:"ECS service name. When combined with --family, tasks of other services sharing the family are excluded."`
 }
 
 func (app *Ecsta) RunDescribe(ctx context.Context, opt *DescribeOption) error {

--- a/ecsta.go
+++ b/ecsta.go
@@ -83,12 +83,15 @@ func (app *Ecsta) describeTasks(ctx context.Context, opt *optionDescribeTasks) (
 func (app *Ecsta) listTasks(ctx context.Context, opt *optionListTasks) ([]types.Task, error) {
 	tasks := []types.Task{}
 	var inputs []*ecs.ListTasksInput
+	// ListTasks API does not accept Family and ServiceName at the same time.
+	// When both are specified, query by Family and post-filter to exclude
+	// tasks belonging to other services that share the same family. This
+	// keeps standalone tasks (typically launched by RunTask, e.g. via
+	// `ecspresso run`) of the same family while filtering out tasks of
+	// sibling services.
 	if opt.family != nil && opt.service != nil {
-		// LisTasks does not support family and service at the same time
-		// spilit into two requests
 		inputs = []*ecs.ListTasksInput{
 			{Cluster: &app.cluster, Family: opt.family},
-			{Cluster: &app.cluster, ServiceName: opt.service},
 		}
 	} else {
 		inputs = []*ecs.ListTasksInput{
@@ -121,6 +124,10 @@ func (app *Ecsta) listTasks(ctx context.Context, opt *optionListTasks) ([]types.
 		}
 	}
 
+	if opt.family != nil && opt.service != nil {
+		tasks = filterTasksByService(tasks, aws.ToString(opt.service))
+	}
+
 	// filter by tags
 	if len(opt.tags) > 0 {
 		tasks = lo.Filter(tasks, func(task types.Task, i int) bool {
@@ -141,6 +148,22 @@ func (app *Ecsta) listTasks(ctx context.Context, opt *optionListTasks) ([]types.
 	return lo.UniqBy(tasks, func(task types.Task) string {
 		return aws.ToString(task.TaskArn)
 	}), nil
+}
+
+// filterTasksByService keeps tasks that belong to the specified service or are
+// not associated with any service (e.g. tasks launched via RunTask). Tasks
+// associated with other services are excluded. Service association is detected
+// by the task's Group field; service-launched tasks have a group of the form
+// "service:<service-name>".
+func filterTasksByService(tasks []types.Task, service string) []types.Task {
+	wantGroup := "service:" + service
+	return lo.Filter(tasks, func(task types.Task, _ int) bool {
+		g := aws.ToString(task.Group)
+		if strings.HasPrefix(g, "service:") {
+			return g == wantGroup
+		}
+		return true
+	})
 }
 
 func (app *Ecsta) listClusters(ctx context.Context) ([]string, error) {

--- a/ecsta_test.go
+++ b/ecsta_test.go
@@ -1,0 +1,75 @@
+package ecsta
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestFilterTasksByService(t *testing.T) {
+	task := func(arn, group string) types.Task {
+		return types.Task{
+			TaskArn: aws.String(arn),
+			Group:   aws.String(group),
+		}
+	}
+	taskNoGroup := types.Task{TaskArn: aws.String("arn:none")}
+
+	all := []types.Task{
+		task("arn:a1", "service:myapp-a"),
+		task("arn:a2", "service:myapp-a"),
+		task("arn:b1", "service:myapp-b"),
+		task("arn:r1", "family:myapp"),
+		task("arn:r2", "custom-group"),
+		taskNoGroup,
+	}
+
+	tests := []struct {
+		name    string
+		service string
+		want    []types.Task
+	}{
+		{
+			name:    "keep target service and standalone tasks",
+			service: "myapp-a",
+			want: []types.Task{
+				task("arn:a1", "service:myapp-a"),
+				task("arn:a2", "service:myapp-a"),
+				task("arn:r1", "family:myapp"),
+				task("arn:r2", "custom-group"),
+				taskNoGroup,
+			},
+		},
+		{
+			name:    "no matching service keeps only standalone tasks",
+			service: "nonexistent",
+			want: []types.Task{
+				task("arn:r1", "family:myapp"),
+				task("arn:r2", "custom-group"),
+				taskNoGroup,
+			},
+		},
+		{
+			name:    "sibling service is excluded",
+			service: "myapp-b",
+			want: []types.Task{
+				task("arn:b1", "service:myapp-b"),
+				task("arn:r1", "family:myapp"),
+				task("arn:r2", "custom-group"),
+				taskNoGroup,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterTasksByService(all, tt.service)
+			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreUnexported(types.Task{})); diff != "" {
+				t.Errorf("filterTasksByService mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/exec.go
+++ b/exec.go
@@ -25,7 +25,7 @@ type ExecOption struct {
 	Command   string  `help:"command to execute" default:"sh"`
 	Container string  `help:"container name"`
 	Family    *string `help:"task definition family name"`
-	Service   *string `help:"ECS service name"`
+	Service   *string `help:"ECS service name. When combined with --family, tasks of other services sharing the family are excluded."`
 
 	catchSignal bool
 	stdout      io.Writer

--- a/list.go
+++ b/list.go
@@ -7,7 +7,7 @@ import (
 
 type ListOption struct {
 	Family     *string           `help:"Task definition family" short:"f"`
-	Service    *string           `help:"Service name" short:"s"`
+	Service    *string           `help:"Service name. When combined with --family, tasks of other services sharing the family are excluded." short:"s"`
 	OutputTags bool              `help:"Output tags of tasks"`
 	Tags       map[string]string `help:"Show only tasks that have specified tags" mapsep:","`
 }

--- a/logs.go
+++ b/logs.go
@@ -28,7 +28,7 @@ type LogsOption struct {
 	Follow    bool          `help:"follow logs" short:"f"`
 	Container string        `help:"container name"`
 	Family    *string       `help:"task definition family name"`
-	Service   *string       `help:"ECS service name"`
+	Service   *string       `help:"ECS service name. When combined with --family, tasks of other services sharing the family are excluded."`
 	JSON      bool          `help:"output as JSON lines" short:"j"`
 }
 

--- a/portforward.go
+++ b/portforward.go
@@ -25,7 +25,7 @@ type PortforwardOption struct {
 	RemoteHost string  `help:"remote host"`
 	L          string  `name:"L" help:"short expression of local-port:remote-host:remote-port" short:"L"`
 	Family     *string `help:"task definition family name"`
-	Service    *string `help:"ECS service name"`
+	Service    *string `help:"ECS service name. When combined with --family, tasks of other services sharing the family are excluded."`
 	Public     bool    `help:"bind to all interfaces (0.0.0.0) instead of localhost only"`
 
 	stdout io.Writer

--- a/stop.go
+++ b/stop.go
@@ -13,7 +13,7 @@ type StopOption struct {
 	ID      string  `help:"task ID"`
 	Force   bool    `help:"stop without confirmation"`
 	Family  *string `help:"task definition family name"`
-	Service *string `help:"ECS service name"`
+	Service *string `help:"ECS service name. When combined with --family, tasks of other services sharing the family are excluded."`
 }
 
 func (app *Ecsta) RunStop(ctx context.Context, opt *StopOption) error {

--- a/trace.go
+++ b/trace.go
@@ -13,7 +13,7 @@ type TraceOption struct {
 	Duration    time.Duration `help:"duration to trace" short:"d" default:"1m"`
 	SNSTopicArn string        `help:"SNS topic ARN"`
 	Family      *string       `help:"task definition family name"`
-	Service     *string       `help:"ECS service name"`
+	Service     *string       `help:"ECS service name. When combined with --family, tasks of other services sharing the family are excluded."`
 	JSON        bool          `help:"output JSON lines" short:"j"`
 }
 


### PR DESCRIPTION
## Summary

When both `--family` and `--service` were specified, `listTasks` previously split the request in two (one by family, one by service) and unioned the results, because the AWS `ListTasks` API does not accept both filters at once. As a side effect, tasks of *other* services that share the same task definition family were always returned even when `--service` was set.

This change makes the combined filter behave as users expect:

- List tasks by family (single request).
- Post-filter by the task's `Group`:
  - Keep tasks whose group is `service:<specified>`.
  - Keep tasks whose group does not start with `service:` (e.g. tasks launched via `RunTask` such as `ecspresso run`).
  - Drop tasks belonging to other services that share the family.

This matches the typical use case where multiple ECS services share a task definition family but the operator wants to scope task operations to a single service while still seeing standalone runs of the same family.

Reported in kayac/ecspresso#1000.

## Notes

- Behavioral change: callers passing both `--family` and `--service` will no longer see sibling services' tasks. Callers that pass only one filter are unaffected.
- Help text on `--service` is updated for all subcommands. README has a new "Filtering tasks by family and service" section that explains the semantics.

## Test plan

- [x] `go test ./...` passes
- [x] `go build -o ecsta ./cmd/ecsta/` succeeds
- [x] Manual: in a cluster with two services `myapp-a` and `myapp-b` sharing family `myapp`, run `ecsta list --family myapp --service myapp-a` and confirm only `myapp-a` tasks (and any `RunTask` tasks of `myapp`) are listed.